### PR TITLE
Updated jcenter url to run on HTTPS

### DIFF
--- a/travis-settings.xml
+++ b/travis-settings.xml
@@ -22,7 +22,7 @@
         <repository>
           <id>central</id>
           <name>bintray</name>
-          <url>http://jcenter.bintray.com</url>
+          <url>https://jcenter.bintray.com</url>
           <snapshots>
             <enabled>false</enabled>
           </snapshots>


### PR DESCRIPTION
Set jcenter url to point on HTTPS.  According to https://jfrog.com/blog/secure-jcenter-with-https/.